### PR TITLE
Add designs for school users who cannot ever order

### DIFF
--- a/app/data/school-details.js
+++ b/app/data/school-details.js
@@ -2,5 +2,7 @@ module.exports = {
   name: 'Rice Lane Primary School',
   type: 'Primary school',
   allocation: 162,
-  can_order: false
+  can_order: false,
+  order_user: false,
+  first_user: false
 }

--- a/app/data/school-details.js
+++ b/app/data/school-details.js
@@ -3,6 +3,6 @@ module.exports = {
   type: 'Primary school',
   allocation: 162,
   can_order: false,
-  order_user: false,
-  first_user: false
+  order_user: true,
+  first_user: true
 }

--- a/app/utils/school-wizard-paths.js
+++ b/app/utils/school-wizard-paths.js
@@ -12,7 +12,7 @@ function schoolWizardPaths (req) {
     '/school/privacy',
     '/school/allocation',
     '/school/order-your-own',
-    ...isOrderUser ? ['/school/you-ordering'] : [],
+    ...isFirstUser ? ['/school/you-ordering'] : [],
     ...isOrderUser ? ['/school/techsource-account'] : [],
     ...isFirstUser ? ['/school/other-ordering'] : [],
     '/school/devices-you-can-order',

--- a/app/utils/school-wizard-paths.js
+++ b/app/utils/school-wizard-paths.js
@@ -4,14 +4,17 @@ const {
 } = require('../utils/wizard-helpers')
 
 function schoolWizardPaths (req) {
+  const isOrderUser = req.session.data['school-details'].order_user
+  const isFirstUser = req.session.data['school-details'].first_user
+
   var paths = [
     '/school/welcome',
     '/school/privacy',
     '/school/allocation',
     '/school/order-your-own',
-    '/school/you-ordering',
-    '/school/techsource-account',
-    '/school/other-ordering',
+    ...isOrderUser ? ['/school/you-ordering'] : [],
+    ...isOrderUser ? ['/school/techsource-account'] : [],
+    ...isFirstUser ? ['/school/other-ordering'] : [],
     '/school/devices-you-can-order',
     '/school/chromebooks',
     '/school/what-next',

--- a/app/views/school/chromebooks.html
+++ b/app/views/school/chromebooks.html
@@ -1,5 +1,5 @@
 {% extends "_wizard-form.html" %}
-{% set title = 'Will your order include a request for Chromebooks?' %}
+{% set title = 'Will your school’s order include a request for Chromebooks?' %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">

--- a/app/views/school/devices-you-can-order.html
+++ b/app/views/school/devices-you-can-order.html
@@ -1,5 +1,6 @@
 {% extends "_wizard-form.html" %}
-{% set title = "Your school can order a range of laptops and tablets" %}
+{% set isOrderUser = data['school-details'].order_user %}
+{% set title = "You can order a range of laptops and tablets" if isOrderUser else "Your school can order a range of laptops and tablets" %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">

--- a/app/views/school/devices-you-can-order.html
+++ b/app/views/school/devices-you-can-order.html
@@ -1,5 +1,5 @@
 {% extends "_wizard-form.html" %}
-{% set title = "You can order a range of laptops and tablets" %}
+{% set title = "Your school can order a range of laptops and tablets" %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">

--- a/app/views/school/devices/order-lockdown.html
+++ b/app/views/school/devices/order-lockdown.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
-{% set title = "Order devices now" %}
+{% set isOrderUser = data['school-details'].order_user %}
+{% set title = "Order devices now" if isOrderUser else "Order devices" %}
 {% set lockdown = false %}
 {% block pageTitle %}{{ title }}{% endblock %}
 
@@ -21,15 +22,30 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      {{ title }}
+      {% if isOrderUser %}
+        {{ title }}
+      {% else %}
+        <span class="govuk-caption-xl">
+          {{ title }}
+        </span>
+        Your school can order {{ data['school-details'].allocation }} devices now
+      {% endif %}
     </h1>
 
-    <h2 class="govuk-heading-m">You can order {{ data['school-details'].allocation }} devices</h2>
-    <p class="govuk-body">Order your devices now, do not delay.</p>
-    <p>They will arrive on the next working day if you order before 4pm.</p>
+    {% if isOrderUser %}
+      <h2 class="govuk-heading-m">You can order {{ data['school-details'].allocation }} devices</h2>
+      <p class="govuk-body">Order your devices now, do not delay.</p>
+      <p>They will arrive on the next working day if you order before 4pm.</p>
 
-    {% include '_shared/order/_help-signing-in.html' %}
-    {% include '_shared/order/_start-now.html' %}
+      {% include '_shared/order/_help-signing-in.html' %}
+      {% include '_shared/order/_start-now.html' %}
+    {% else %}
+      <p>You do not have a TechSource account. Someone else must place your school’s orders.</p>
+
+      <p><a href="/school/users">Go to manage users to see who can place orders, or give yourself access</a>.</p>
+    {% endif %}
+
+
   </div>
 </div>
 {% endblock %}

--- a/app/views/school/devices/order.html
+++ b/app/views/school/devices/order.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
-{% set title = "You cannot order devices yet" %}
+{% set isOrderUser = data['school-details'].order_user %}
+{% set title = "You cannot order devices yet" if isOrderUser else "Your school cannot order devices yet" %}
 {% set lockdown = false %}
 {% block pageTitle %}{{ title }}{% endblock %}
 
@@ -28,6 +29,12 @@
 
     {% set requestLink = '/school/devices/request-devices' %}
     {% include '_shared/request-devices/_who.html' %}
+
+    {% if not isOrderUser %}
+      <h2 class="govuk-heading-m">You won’t be able to place orders yourself</h2>
+      <p>You do not have a TechSource account. Someone else will need to place your school’s orders.</p>
+      <p><a href="/school/users">Go to manage users to see who can place orders, or give yourself access</a>.</p>
+    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/app/views/school/order-your-own.html
+++ b/app/views/school/order-your-own.html
@@ -1,5 +1,6 @@
 {% extends "_wizard-form.html" %}
-{% set title = "You can only order your full allocation if local restrictions are confirmed" %}
+{% set isOrderUser = data['school-details'].order_user %}
+{% set title = "You can only order your full allocation if local restrictions are confirmed" if isOrderUser else "Your school can only order its full allocation if local restrictions are confirmed" %}
 
 {% block form %}
   <h1 class="govuk-heading-l">

--- a/app/views/school/welcome.html
+++ b/app/views/school/welcome.html
@@ -1,4 +1,5 @@
 {% extends "_wizard-form.html" %}
+{% set isOrderUser = data['school-details'].order_user %}
 {% set title = "You’re signed in as " + data['school-details'].name %}
 
 {% block form %}
@@ -9,7 +10,9 @@
   <p>You can use the ‘Get help with technology’ service to:</p>
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
     <li>manage who will order devices for your school</li>
-    <li>access the Computacenter TechSource website to place orders when devices are made available</li>
+    {% if isOrderUser %}
+      <li>access the Computacenter TechSource website to place orders when devices are made available</li>
+    {% endif %}
     <li>give us technical details for Chromebooks if you’ll be ordering them</li>
     <li>view your device allocation</li>
   </ul>


### PR DESCRIPTION
For subsequent users after the first, in the welcome flow hide:

* will you be ordering screen
* add new users screen

For non-order users, in the welcome flow, hide:

* you'll get a techsource account screen

Tweak page titles based on whether the user can order or not.

## Order screens

| School cannot order | School can order |
| -- | -- |
| ![Screen Shot 2020-09-01 at 13 42 06](https://user-images.githubusercontent.com/319055/91852639-05192580-ec59-11ea-81bd-77e9f59c0b71.png) | ![Screen Shot 2020-09-01 at 13 42 14](https://user-images.githubusercontent.com/319055/91852648-06e2e900-ec59-11ea-9261-a5f654c528ae.png) |

